### PR TITLE
Py3 support

### DIFF
--- a/repoze/who/plugins/use_beaker.py
+++ b/repoze/who/plugins/use_beaker.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 "repoze.who identifier plugin that persists to beaker sessions"
+from past.builtins import basestring
+from builtins import object
 import re
 
-from zope.interface import implements
+from zope.interface import implementer
 
 from repoze.who.interfaces import IIdentifier
 
@@ -11,9 +13,9 @@ SPLIT_RE = re.compile(r'\s*,\s*')
 PERSIST_KEYS = ['userdata', 'tokens']
 
 
+@implementer(IIdentifier)
 class UseBeakerPlugin(object):
     "Identify plugin that uses beaker"
-    implements(IIdentifier)
 
     def __init__(  # pylint: disable=dangerous-default-value
             self, key_name='repoze.who.tkt',

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,6 @@
 from setuptools import setup, find_packages
 from os.path import join, dirname
 import sys
-# Fool distutils to accept more than ASCII
-reload(sys).setdefaultencoding('utf-8')
 
 REQUIRES = [
     "PasteScript",

--- a/tests/test_beaker.py
+++ b/tests/test_beaker.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from builtins import str
+from builtins import object
 from unittest import TestCase
 
 from beaker.middleware import SessionMiddleware
@@ -89,7 +91,7 @@ class TestUseBeakerPlugin(TestBaseUseBeakerPlugin):
         plugin.forget(environ, identity)
         r = plugin.identify(environ)
         self.assertEqual(r, None)
-        self.assert_(not environ['beaker.session'].has_key('repoze.who.tkt'))
+        self.assert_('repoze.who.tkt' not in environ['beaker.session'])
 
         plugin.remember(environ, identity)
         plugin.remember(environ, identity)

--- a/tests/test_beaker_attributes.py
+++ b/tests/test_beaker_attributes.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from test_beaker import TestBaseUseBeakerPlugin
+from __future__ import absolute_import
+from .test_beaker import TestBaseUseBeakerPlugin
 
 class TestUseBeakerPluginAttributes(TestBaseUseBeakerPlugin):
 

--- a/tests/test_beaker_implementation_dict.py
+++ b/tests/test_beaker_implementation_dict.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import
+from builtins import str
 from unittest import TestCase
 
 from beaker.middleware import SessionMiddleware
 from webob import Request, Response
 from webtest import TestApp
 from repoze.who.tests.test_middleware import DummyIdentifier
-from test_beaker import TestBaseUseBeakerPlugin
+from .test_beaker import TestBaseUseBeakerPlugin
 
 class TestUseBeakerPluginDictionaryImplementation(TestBaseUseBeakerPlugin):
 
@@ -40,7 +42,7 @@ class TestUseBeakerPluginDictionaryImplementation(TestBaseUseBeakerPlugin):
         plugin.forget(environ, identity)
         r = plugin.identify(environ)
         self.assertEqual(r, None)
-        self.assert_(not environ['beaker.session'].has_key('repoze.who.tkt'))
+        self.assert_('repoze.who.tkt' not in environ['beaker.session'])
 
         plugin.remember(environ, identity)
         plugin.remember(environ, identity)


### PR DESCRIPTION
Ran `futurize . -w` at root of model, updated `implements` (no longer supported) to `@implementer` pattern